### PR TITLE
Adding support to rails 8

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.7", "3.1", "3.2", "3.3"]
-        rails-version: ["5", "6", "7", "8"]
+        ruby-version: ["3.2", "3.3"]
+        rails-version: ["7", "8"]
 
     steps:
       - uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
       - run: bundle install
 
       - name: Publish to GPR

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: ["2.7", "3.1", "3.2"]
-        rails-version: ["5", "6", "7"]
+        rails-version: ["5", "6", "7", "8"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.7", "3.1", "3.2"]
+        ruby-version: ["2.7", "3.1", "3.2", "3.3"]
         rails-version: ["5", "6", "7", "8"]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Updating the README file
 - Adding more test cases
 
-  ## [0.2.25] - 2024-11-08
+## [0.2.25] - 2024-11-08
 
 - Adding support to Rails 8. This gem now supports from Rails 5 up to version 8.
 - Updating the version number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,9 @@
 - Adding support for app/config/initializers/simple_icons.rb to override the default CDN
 - Updating the README file
 - Adding more test cases
+
+  ## [0.2.25] - 2024-11-08
+
+- Adding support to Rails 8. This gem now supports from Rails 5 up to version 8.
+- Updating the version number
+- Upgrading the README.md

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ version 0.2.x `gem 'simple_icons_rails', '~> 0.2.0'`
 
 version 0.2.25 support Rails 8.
 
+**In 2025 we will remove support to Rails 5 and Ruby 2.7** Versions following version 0.2.25 will support Rails 6 to 8 and Ruby 3.1 to 3.3 (or higher). If you need support for Rails version 5 use either 0.1.x or 0.2.22.
+
+Thank you for your understanding.
+
 ## Description
 
 The Simple Icons Rails Gem is a Ruby gem designed for importing and using the icons from [Simple Icons](https://simpleicons.org/) in your Rails projects. Simple Icons provides a collection of more than 2500 SVG icons for various popular brands. <img src="https://img.shields.io/badge/dynamic/json?color=informational&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json" alt="Number of icons currently in the library"/>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 ## IMPORTANT
 version 0.1.x `gem 'simple-icons-rails', '~> 0.1.0'`<br/>
 version 0.2.x `gem 'simple_icons_rails', '~> 0.2.0'` 
+
+version 0.2.25 support Rails 8.
+
 ## Description
 
 The Simple Icons Rails Gem is a Ruby gem designed for importing and using the icons from [Simple Icons](https://simpleicons.org/) in your Rails projects. Simple Icons provides a collection of more than 2500 SVG icons for various popular brands. <img src="https://img.shields.io/badge/dynamic/json?color=informational&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json" alt="Number of icons currently in the library"/>

--- a/lib/simple_icons_rails/version.rb
+++ b/lib/simple_icons_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SimpleIconsRails
-  VERSION = "0.2.22".freeze
+  VERSION = "0.2.25".freeze
 end

--- a/simple_icons_rails.gemspec
+++ b/simple_icons_rails.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["CHANGELOG.md", "LICENSE.md", "README.md", "lib/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rails", ">= 5.0", "< 8.0"
+  spec.add_runtime_dependency "rails", ">= 5.0", "< 9.0"
   # spec.add_dependency "actionview"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
Adding support to Rails 8
Announcing that Rails 5 and Ruby 2.7 will be removed in 2025